### PR TITLE
Initialize DB setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Arivu Foods Inventory System
+
+Version: 0.1.0
+
+This repository contains initial scripts to set up the inventory database.
+
+## Changes
+- Added `schema.sql` extracted from documentation
+- Added `database.py` for SQLAlchemy connection
+- Added `init_db.py` to create tables
+- Added `analyze_schema.py` for quick schema inspection
+
+## Quick Start
+1. Install dependencies: `pip install sqlalchemy`
+2. Run `python init_db.py` to create `arivu_foods_inventory.db`.
+3. Inspect tables via `python analyze_schema.py`.
+
+## Project Status
+Early setup phase: database schema creation scripts only.

--- a/analyze_schema.py
+++ b/analyze_schema.py
@@ -1,0 +1,38 @@
+"""Simple analyzer for schema.sql to list tables and columns.
+
+WHY: provide quick insight into schema structure for developers.
+WHAT: Parses schema.sql for CREATE TABLE blocks.
+HOW: run `python analyze_schema.py` after updates to verify tables.
+"""
+
+import re
+from pathlib import Path
+
+SCHEMA_FILE = Path(__file__).parent / "schema.sql"
+
+create_re = re.compile(r"CREATE TABLE (\w+) \(")
+column_re = re.compile(r"\s*(\w+) [A-Z]+")
+
+
+def analyze():
+    tables = {}
+    lines = SCHEMA_FILE.read_text().splitlines()
+    current = None
+    for line in lines:
+        m = create_re.match(line)
+        if m:
+            current = m.group(1)
+            tables[current] = []
+            continue
+        if current and line.startswith("    "):
+            col = column_re.match(line)
+            if col:
+                tables[current].append(col.group(1))
+        elif line.startswith(");"):
+            current = None
+    for tbl, cols in tables.items():
+        print(f"{tbl}: {', '.join(cols)}")
+
+
+if __name__ == "__main__":
+    analyze()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,23 @@
+"""Database connection setup.
+
+WHY: Provide a simple SQLite connection using SQLAlchemy.
+WHAT: sets up engine, session, and Base classes.
+HOW: modify DATABASE_URL or extend with env vars to change DB later.
+Closes: #1 (initial db setup).
+"""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./arivu_foods_inventory.db"
+
+engine = create_engine(DATABASE_URL, echo=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,28 @@
+"""Initialize database tables from schema.sql.
+
+WHY: Create all tables for initial setup using raw SQL.
+WHAT: Reads schema.sql and executes it using SQLite connection.
+HOW: Use for initial deployments; roll back by dropping DB file.
+Closes: #1.
+"""
+
+import sqlite3
+from pathlib import Path
+
+SCHEMA_FILE = Path(__file__).parent / "schema.sql"
+DB_FILE = Path("arivu_foods_inventory.db")
+
+
+def create_tables():
+    sql = SCHEMA_FILE.read_text()
+    conn = sqlite3.connect(DB_FILE)
+    try:
+        conn.executescript(sql)
+        conn.commit()
+        print("Tables created successfully")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    create_tables()

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,95 @@
+-- Schema extracted from sqlscema.md
+-- Contains table definitions for Arivu Foods Inventory
+
+CREATE TABLE products (
+    product_id VARCHAR(50) PRIMARY KEY,
+    product_name VARCHAR(255) NOT NULL,
+    unit_of_measure VARCHAR(50) NOT NULL,
+    standard_pack_size DECIMAL(10, 2) NOT NULL,
+    mrp DECIMAL(10, 2)
+);
+
+CREATE TABLE locations (
+    location_id VARCHAR(50) PRIMARY KEY,
+    location_name VARCHAR(255) NOT NULL,
+    location_type VARCHAR(50) NOT NULL,
+    address VARCHAR(500),
+    city VARCHAR(100),
+    state VARCHAR(100),
+    zip_code VARCHAR(20),
+    country VARCHAR(100) DEFAULT 'India'
+);
+
+CREATE TABLE retail_partners (
+    store_id VARCHAR(50) PRIMARY KEY,
+    location_id VARCHAR(50) NOT NULL,
+    store_name VARCHAR(255) NOT NULL,
+    contact_person VARCHAR(255),
+    contact_number VARCHAR(50),
+    email VARCHAR(255),
+    CONSTRAINT fk_retail_location FOREIGN KEY (location_id) REFERENCES locations(location_id)
+);
+
+CREATE TABLE agents (
+    agent_id VARCHAR(50) PRIMARY KEY,
+    agent_name VARCHAR(255) NOT NULL,
+    contact_number VARCHAR(50),
+    email VARCHAR(255)
+);
+
+CREATE TABLE batches (
+    batch_id VARCHAR(50) PRIMARY KEY,
+    product_id VARCHAR(50) NOT NULL,
+    date_manufactured DATE NOT NULL,
+    quantity_produced INT NOT NULL,
+    expiry_date DATE,
+    remarks TEXT,
+    CONSTRAINT fk_batch_product FOREIGN KEY (product_id) REFERENCES products(product_id)
+);
+
+CREATE TABLE current_stock (
+    stock_id VARCHAR(50) PRIMARY KEY,
+    product_id VARCHAR(50) NOT NULL,
+    batch_id VARCHAR(50) NOT NULL,
+    location_id VARCHAR(50) NOT NULL,
+    quantity INT NOT NULL CHECK (quantity >= 0),
+    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_product_batch_location UNIQUE (product_id, batch_id, location_id),
+    CONSTRAINT fk_current_stock_product FOREIGN KEY (product_id) REFERENCES products(product_id),
+    CONSTRAINT fk_current_stock_batch FOREIGN KEY (batch_id) REFERENCES batches(batch_id),
+    CONSTRAINT fk_current_stock_location FOREIGN KEY (location_id) REFERENCES locations(location_id)
+);
+
+CREATE TABLE stock_movements (
+    movement_id VARCHAR(50) PRIMARY KEY,
+    product_id VARCHAR(50) NOT NULL,
+    batch_id VARCHAR(50) NOT NULL,
+    movement_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    movement_type VARCHAR(50) NOT NULL,
+    source_location_id VARCHAR(50),
+    destination_location_id VARCHAR(50),
+    quantity INT NOT NULL CHECK (quantity > 0),
+    agent_id VARCHAR(50),
+    remarks TEXT,
+    CONSTRAINT fk_movement_product FOREIGN KEY (product_id) REFERENCES products(product_id),
+    CONSTRAINT fk_movement_batch FOREIGN KEY (batch_id) REFERENCES batches(batch_id),
+    CONSTRAINT fk_movement_source_location FOREIGN KEY (source_location_id) REFERENCES locations(location_id),
+    CONSTRAINT fk_movement_destination_location FOREIGN KEY (destination_location_id) REFERENCES locations(location_id),
+    CONSTRAINT fk_movement_agent FOREIGN KEY (agent_id) REFERENCES agents(agent_id)
+);
+
+CREATE TABLE retail_sales (
+    sale_id VARCHAR(50) PRIMARY KEY,
+    sale_date DATE NOT NULL,
+    store_id VARCHAR(50) NOT NULL,
+    product_id VARCHAR(50) NOT NULL,
+    batch_id VARCHAR(50),
+    quantity_sold INT NOT NULL CHECK (quantity_sold > 0),
+    sales_agent_id VARCHAR(50),
+    sale_price_per_unit DECIMAL(10, 2),
+    remarks TEXT,
+    CONSTRAINT fk_retail_sale_store FOREIGN KEY (store_id) REFERENCES retail_partners(store_id),
+    CONSTRAINT fk_retail_sale_product FOREIGN KEY (product_id) REFERENCES products(product_id),
+    CONSTRAINT fk_retail_sale_batch FOREIGN KEY (batch_id) REFERENCES batches(batch_id),
+    CONSTRAINT fk_retail_sale_agent FOREIGN KEY (sales_agent_id) REFERENCES agents(agent_id)
+);


### PR DESCRIPTION
## Summary
- add schema.sql extracted from docs
- add SQLAlchemy database configuration
- add init_db.py to create tables
- add analyze_schema.py for quick inspection
- document current status in README

## Testing
- `python analyze_schema.py`
- `python init_db.py`


------
https://chatgpt.com/codex/tasks/task_e_685d0b8ca110832ab11ae0ec23de02a5