### PR TITLE
Add FastAPI backend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # Arivu Foods Inventory System
 
-Version: 0.1.0
+Version: 0.2.0
 
-This repository contains initial scripts to set up the inventory database.
+This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
 ## Changes
 - Added `schema.sql` extracted from documentation
 - Added `database.py` for SQLAlchemy connection
 - Added `init_db.py` to create tables
 - Added `analyze_schema.py` for quick schema inspection
+- **New:** `models.py` with ORM models
+- **New:** `main.py` FastAPI app exposing `/products` endpoint
+- **Updated:** `product_list.html` now loads products from API
 
 ## Quick Start
-1. Install dependencies: `pip install sqlalchemy`
+1. Install dependencies: `pip install fastapi uvicorn sqlalchemy`
 2. Run `python init_db.py` to create `arivu_foods_inventory.db`.
-3. Inspect tables via `python analyze_schema.py`.
+3. Start API server: `uvicorn main:app --reload`
+4. Open `product_list.html` in browser to see product list.
+
+## API Example
+Fetch products via cURL:
+
+```bash
+curl http://localhost:8000/products
+```
 
 ## Project Status
-Early setup phase: database schema creation scripts only.
+Basic API running; database schema and product listing implemented.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+"""FastAPI app exposing inventory endpoints.
+
+WHY: Provide backend API to access DB data.
+WHAT: Adds /products endpoint for listing products.
+HOW: Extend by adding CRUD routes; rollback by removing this file.
+Closes: #2.
+"""
+
+from fastapi import FastAPI, Depends
+from sqlalchemy.orm import Session
+
+from database import get_db, Base, engine
+from models import Product
+
+# Create tables if not already present (initial migration)
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Arivu Foods Inventory API")
+
+@app.get("/products")
+def list_products(db: Session = Depends(get_db)):
+    """Return all products."""
+    products = db.query(Product).all()
+    return [
+        {
+            "product_id": p.product_id,
+            "product_name": p.product_name,
+            "unit_of_measure": p.unit_of_measure,
+            "standard_pack_size": float(p.standard_pack_size),
+            "mrp": float(p.mrp) if p.mrp else None,
+        }
+        for p in products
+    ]

--- a/models.py
+++ b/models.py
@@ -1,0 +1,29 @@
+"""SQLAlchemy models for FastAPI backend.
+
+WHY: Translate tables to ORM for use in API.
+WHAT: Defines Product and Location models.
+HOW: Extend by adding remaining tables; rollback by deleting this file.
+Closes: #2 (basic API models).
+"""
+
+from sqlalchemy import Column, String, DECIMAL
+from database import Base
+
+class Product(Base):
+    __tablename__ = 'products'
+    product_id = Column(String(50), primary_key=True)
+    product_name = Column(String(255), nullable=False)
+    unit_of_measure = Column(String(50), nullable=False)
+    standard_pack_size = Column(DECIMAL(10, 2), nullable=False)
+    mrp = Column(DECIMAL(10, 2))
+
+class Location(Base):
+    __tablename__ = 'locations'
+    location_id = Column(String(50), primary_key=True)
+    location_name = Column(String(255), nullable=False)
+    location_type = Column(String(50), nullable=False)
+    address = Column(String(500))
+    city = Column(String(100))
+    state = Column(String(100))
+    zip_code = Column(String(20))
+    country = Column(String(100), default='India')

--- a/product_list.html
+++ b/product_list.html
@@ -61,26 +61,26 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <!-- Custom JavaScript for this page (if it were standalone) -->
     <script>
-        // This script would typically fetch data from API and populate the table
-        // For dynamic loading into index.html, this logic would reside in js/main.js or js/components.js
+        // WHY: Load product data from backend API
+        // WHAT: fetches /products endpoint and renders into table
+        // HOW: call fetchProducts() on page load; remove or modify to roll back
+        // Closes: #2
         document.addEventListener('DOMContentLoaded', () => {
-            console.log("Product list page loaded.");
-            // Example of how you might fetch and render data:
-            // async function loadProducts() {
-            //     const response = await fetch('http://localhost:8000/products'); // Your API endpoint
-            //     const products = await response.json();
-            //     const tbody = document.getElementById('productListTableBody');
-            //     tbody.innerHTML = ''; // Clear static content
-            //     products.forEach(product => {
-            //         const row = tbody.insertRow();
-            //         row.insertCell().textContent = product.product_id;
-            //         row.insertCell().textContent = product.product_name;
-            //         row.insertCell().textContent = product.unit_of_measure;
-            //         row.insertCell().textContent = product.standard_pack_size;
-            //         row.insertCell().textContent = product.mrp;
-            //     });
-            // }
-            // loadProducts();
+            async function loadProducts() {
+                const response = await fetch('http://localhost:8000/products');
+                const products = await response.json();
+                const tbody = document.getElementById('productListTableBody');
+                tbody.innerHTML = '';
+                products.forEach(product => {
+                    const row = tbody.insertRow();
+                    row.insertCell().textContent = product.product_id;
+                    row.insertCell().textContent = product.product_name;
+                    row.insertCell().textContent = product.unit_of_measure;
+                    row.insertCell().textContent = product.standard_pack_size;
+                    row.insertCell().textContent = product.mrp;
+                });
+            }
+            loadProducts();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add SQLAlchemy models
- build FastAPI app with `/products` endpoint
- load product data via API in `product_list.html`
- document new version and provide quickstart with cURL example

## Testing
- `python init_db.py`
- `python -m uvicorn main:app --reload` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_685d0f356590832a886c79ecede55f21