### PR TITLE
Add POST product endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.2.0
+Version: 0.3.0
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -12,6 +12,7 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** `models.py` with ORM models
 - **New:** `main.py` FastAPI app exposing `/products` endpoint
 - **Updated:** `product_list.html` now loads products from API
+- **New:** `POST /products` API to add products and frontend form
 
 ## Quick Start
 1. Install dependencies: `pip install fastapi uvicorn sqlalchemy`
@@ -26,5 +27,13 @@ Fetch products via cURL:
 curl http://localhost:8000/products
 ```
 
+Create a new product via cURL:
+
+```bash
+curl -X POST http://localhost:8000/products \
+     -H 'Content-Type: application/json' \
+     -d '{"product_id":"NEW1","product_name":"Sample","unit_of_measure":"kg","standard_pack_size":1,"mrp":100}'
+```
+
 ## Project Status
-Basic API running; database schema and product listing implemented.
+Basic API running; products can be listed and added via the new form and endpoint.

--- a/main.py
+++ b/main.py
@@ -6,8 +6,9 @@ HOW: Extend by adding CRUD routes; rollback by removing this file.
 Closes: #2.
 """
 
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
+from pydantic import BaseModel
 
 from database import get_db, Base, engine
 from models import Product
@@ -16,6 +17,15 @@ from models import Product
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Arivu Foods Inventory API")
+
+
+class ProductCreate(BaseModel):
+    """Schema for creating a product."""
+    product_id: str
+    product_name: str
+    unit_of_measure: str
+    standard_pack_size: float
+    mrp: float | None = None
 
 @app.get("/products")
 def list_products(db: Session = Depends(get_db)):
@@ -31,3 +41,19 @@ def list_products(db: Session = Depends(get_db)):
         }
         for p in products
     ]
+
+
+@app.post("/products", status_code=201)
+def create_product(product: ProductCreate, db: Session = Depends(get_db)):
+    """Create a new product in the database."""
+    # WHY: allow backend to manage DB by inserting products (Closes: #3)
+    # WHAT: adds POST /products route for creating new products
+    # HOW: check for existing ID then insert; rollback by removing this func
+    existing = db.get(Product, product.product_id)
+    if existing:
+        raise HTTPException(status_code=400, detail="Product ID already exists")
+    db_product = Product(**product.dict())
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+    return {"message": "Product created", "product_id": db_product.product_id}

--- a/product_list.html
+++ b/product_list.html
@@ -16,6 +16,30 @@
             <input type="text" class="form-control" id="productSearchInput" placeholder="Search products...">
             <button class="btn btn-outline-primary" type="button" id="productSearchButton">Search</button>
         </div>
+
+        <form id="addProductForm" class="row g-2 mb-4">
+            <!-- WHY: allow adding products from UI -->
+            <!-- WHAT: posts to /products endpoint -->
+            <!-- HOW: extend fields for more attributes or remove form to rollback -->
+            <div class="col-md-2">
+                <input type="text" class="form-control" id="productId" placeholder="ID" required>
+            </div>
+            <div class="col-md-3">
+                <input type="text" class="form-control" id="productName" placeholder="Name" required>
+            </div>
+            <div class="col-md-2">
+                <input type="text" class="form-control" id="unit" placeholder="Unit" required>
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="0.01" class="form-control" id="packSize" placeholder="Pack Size" required>
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="0.01" class="form-control" id="mrp" placeholder="MRP">
+            </div>
+            <div class="col-md-1">
+                <button type="submit" class="btn btn-primary w-100">Add</button>
+            </div>
+        </form>
         <div class="table-responsive">
             <table class="table table-hover table-striped border rounded-3 overflow-hidden">
                 <thead class="bg-light">
@@ -80,6 +104,29 @@
                     row.insertCell().textContent = product.mrp;
                 });
             }
+
+            const form = document.getElementById('addProductForm');
+            form.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                // WHY: send new product data to backend API (Closes: #3)
+                // WHAT: POST /products fetch call
+                // HOW: modify fields to extend; remove listener to rollback
+                const product = {
+                    product_id: document.getElementById('productId').value,
+                    product_name: document.getElementById('productName').value,
+                    unit_of_measure: document.getElementById('unit').value,
+                    standard_pack_size: parseFloat(document.getElementById('packSize').value),
+                    mrp: document.getElementById('mrp').value || null
+                };
+                await fetch('http://localhost:8000/products', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify(product)
+                });
+                form.reset();
+                loadProducts();
+            });
+
             loadProducts();
         });
     </script>


### PR DESCRIPTION
## Summary
- allow adding new products via POST `/products`
- display a form in `product_list.html` and hook up API call
- document new endpoint and bump version to 0.3.0

## Testing
- `python -m uvicorn main:app --reload` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_685d106ac2a8832a92277b1928ada141