### PR TITLE
Implement dashboard endpoints and service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.4.0
+Version: 0.5.0
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -15,11 +15,14 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** `POST /products` API to add products and frontend form
 - **New:** `/batches`, `/stock-movements`, `/expiring-stock` API endpoints
 - **Updated:** Dashboards and product list now use these endpoints
+- **New:** service layer (`services.py`) with aggregation logic
+- **New:** dashboard endpoints `/dashboard/arivu` and `/dashboard/store/{id}`
+- **New:** environment variable `DATABASE_URL` controls database connection
 
 ## Quick Start
 1. Install dependencies: `pip install fastapi uvicorn sqlalchemy`
 2. Run `python init_db.py` to (re)create `arivu_foods_inventory.db` with all tables.
-3. Start API server: `uvicorn main:app --reload`
+3. Start API server: `uvicorn main:app --reload` (set `DATABASE_URL` as needed)
 4. Open `product_list.html` in browser to see product list.
 
 ## API Example
@@ -51,5 +54,17 @@ curl -X POST http://localhost:8000/products \
      -d '{"product_id":"NEW1","product_name":"Sample","unit_of_measure":"kg","standard_pack_size":1,"mrp":100}'
 ```
 
+Fetch dashboard summary via cURL:
+
+```bash
+curl http://localhost:8000/dashboard/arivu
+```
+
+Fetch locations via cURL:
+
+```bash
+curl http://localhost:8000/locations
+```
+
 ## Project Status
-Version 0.4.0 extends the API with batch tracking, stock movements, and expirying-stock reporting. Frontend pages now display batch data and show expiring counts.
+Version 0.5.0 adds a service layer, environment-based DB config, and dashboard APIs for aggregated data.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -101,18 +101,21 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             console.log("Arivu Foods Dashboard loaded.");
-            // WHY: update expiring count using new API (Closes: #4)
-            async function loadExpiring() {
+            // WHY: load aggregate dashboard data from new API (Closes: #6)
+            async function loadDashboard() {
                 try {
-                    const resp = await fetch('http://localhost:8000/expiring-stock');
+                    const resp = await fetch('http://localhost:8000/dashboard/arivu');
                     const data = await resp.json();
-                    document.getElementById('expiringProductsCount').textContent = data.length;
+                    document.getElementById('totalProductsCount').textContent = data.total_products;
+                    document.getElementById('mainWarehouseStock').textContent = data.warehouse_stock;
+                    document.getElementById('retailPartnerStock').textContent = data.retail_stock;
+                    document.getElementById('expiringProductsCount').textContent = data.expiring_soon;
                 } catch (err) {
-                    console.error('Failed to load expiring stock', err);
+                    console.error('Failed to load dashboard', err);
                 }
             }
 
-            loadExpiring();
+            loadDashboard();
         });
     </script>
 </body>

--- a/database.py
+++ b/database.py
@@ -8,8 +8,12 @@ Closes: #1 (initial db setup).
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+import os
 
-DATABASE_URL = "sqlite:///./arivu_foods_inventory.db"
+# WHY: allow DB path configuration via environment variable for deployment
+# WHAT: reads DATABASE_URL from os.environ, defaulting to local SQLite file
+# HOW: set DATABASE_URL env var to new connection string to extend; remove env var usage to roll back
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./arivu_foods_inventory.db")
 
 engine = create_engine(DATABASE_URL, echo=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/models.py
+++ b/models.py
@@ -8,6 +8,10 @@ Closes: #2 (basic API models).
 
 from sqlalchemy import Column, String, DECIMAL, Date, Integer, ForeignKey, TIMESTAMP
 
+# WHY: add remaining tables from schema for fuller tracking (Closes: #6)
+# WHAT: new ORM models for partners, agents, stock and sales
+# HOW: extend queries with relationships; remove models to roll back
+
 from database import Base
 
 class Product(Base):
@@ -58,5 +62,50 @@ class StockMovement(Base):
     destination_location_id = Column(String(50), ForeignKey('locations.location_id'))
     quantity = Column(Integer, nullable=False)
     agent_id = Column(String(50), ForeignKey('agents.agent_id'))
+    remarks = Column(String)
+
+
+class RetailPartner(Base):
+    """Retail stores carrying products."""
+    __tablename__ = 'retail_partners'
+    store_id = Column(String(50), primary_key=True)
+    location_id = Column(String(50), ForeignKey('locations.location_id'), nullable=False)
+    store_name = Column(String(255), nullable=False)
+    contact_person = Column(String(255))
+    contact_number = Column(String(50))
+    email = Column(String(255))
+
+
+class Agent(Base):
+    """Sales/dispatch agents."""
+    __tablename__ = 'agents'
+    agent_id = Column(String(50), primary_key=True)
+    agent_name = Column(String(255), nullable=False)
+    contact_number = Column(String(50))
+    email = Column(String(255))
+
+
+class CurrentStock(Base):
+    """Current quantity of each batch at each location."""
+    __tablename__ = 'current_stock'
+    stock_id = Column(String(50), primary_key=True)
+    product_id = Column(String(50), ForeignKey('products.product_id'), nullable=False)
+    batch_id = Column(String(50), ForeignKey('batches.batch_id'), nullable=False)
+    location_id = Column(String(50), ForeignKey('locations.location_id'), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    last_updated = Column(TIMESTAMP)
+
+
+class RetailSale(Base):
+    """Sales recorded at partner stores."""
+    __tablename__ = 'retail_sales'
+    sale_id = Column(String(50), primary_key=True)
+    sale_date = Column(Date, nullable=False)
+    store_id = Column(String(50), ForeignKey('retail_partners.store_id'), nullable=False)
+    product_id = Column(String(50), ForeignKey('products.product_id'), nullable=False)
+    batch_id = Column(String(50), ForeignKey('batches.batch_id'))
+    quantity_sold = Column(Integer, nullable=False)
+    sales_agent_id = Column(String(50), ForeignKey('agents.agent_id'))
+    sale_price_per_unit = Column(DECIMAL(10, 2))
     remarks = Column(String)
 

--- a/services.py
+++ b/services.py
@@ -1,0 +1,112 @@
+
+"""Business logic functions for FastAPI routes.
+
+WHY: separate DB queries from routes for reuse and testing.
+WHAT: CRUD helpers and dashboard aggregations.
+HOW: extend with more complex queries; remove usages to roll back.
+Closes: #6
+"""
+
+from sqlalchemy.orm import Session
+from sqlalchemy import func, and_
+from datetime import date, timedelta
+
+from models import (
+    Product,
+    Batch,
+    StockMovement,
+    CurrentStock,
+    RetailSale,
+    Location,
+)
+
+# --- CRUD helpers ---
+
+def get_all_products(db: Session):
+    return db.query(Product).all()
+
+
+def create_product(db: Session, data: dict) -> Product:
+    product = Product(**data)
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def get_all_batches(db: Session):
+    return db.query(Batch).all()
+
+
+def create_batch(db: Session, data: dict) -> Batch:
+    batch = Batch(**data)
+    db.add(batch)
+    db.commit()
+    db.refresh(batch)
+    return batch
+
+
+def get_all_movements(db: Session):
+    return db.query(StockMovement).all()
+
+
+def create_movement(db: Session, data: dict) -> StockMovement:
+    move = StockMovement(**data)
+    db.add(move)
+    db.commit()
+    db.refresh(move)
+    return move
+
+# --- Dashboard aggregations ---
+
+def get_total_products_count(db: Session) -> int:
+    return db.query(func.count(Product.product_id)).scalar() or 0
+
+
+def get_total_warehouse_stock(db: Session) -> int:
+    return (
+        db.query(func.coalesce(func.sum(CurrentStock.quantity), 0))
+        .join(Location, CurrentStock.location_id == Location.location_id)
+        .filter(Location.location_type == "Warehouse")
+        .scalar()
+    )
+
+
+def get_total_retail_stock(db: Session) -> int:
+    return (
+        db.query(func.coalesce(func.sum(CurrentStock.quantity), 0))
+        .join(Location, CurrentStock.location_id == Location.location_id)
+        .filter(Location.location_type == "Retail Store")
+        .scalar()
+    )
+
+
+def get_expiring_units_count(db: Session, days: int = 60) -> int:
+    cutoff = date.today() + timedelta(days=days)
+    return (
+        db.query(func.coalesce(func.sum(CurrentStock.quantity), 0))
+        .join(Batch, CurrentStock.batch_id == Batch.batch_id)
+        .filter(and_(Batch.expiry_date != None, Batch.expiry_date <= cutoff))
+        .scalar()
+    )
+
+
+def get_recent_movements(db: Session, limit: int = 5):
+    return db.query(StockMovement).order_by(StockMovement.movement_date.desc()).limit(limit).all()
+
+
+def get_store_current_stock(db: Session, store_id: str) -> int:
+    return (
+        db.query(func.coalesce(func.sum(CurrentStock.quantity), 0))
+        .filter(CurrentStock.location_id == store_id)
+        .scalar()
+    )
+
+
+def get_store_sales_today(db: Session, store_id: str) -> int:
+    today = date.today()
+    return (
+        db.query(func.coalesce(func.sum(RetailSale.quantity_sold), 0))
+        .filter(and_(RetailSale.store_id == store_id, RetailSale.sale_date == today))
+        .scalar()
+    )

--- a/store_partner_dashboard.html
+++ b/store_partner_dashboard.html
@@ -85,55 +85,44 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             console.log("Store Partner Dashboard loaded.");
-            // This logic would ideally be in js/components.js and called by main.js
-            // async function loadStoreDashboard(storeId) {
-            //     document.getElementById('dashboardContent').classList.remove('d-none'); // Show content
-            //     // Example: Fetch and populate data for the selected store
-            //     // const storeStock = await api.fetchCurrentStockByLocation(storeId);
-            //     // document.getElementById('storeCurrentStock').textContent = storeStock.reduce((sum, item) => sum + item.quantity, 0);
 
-            //     // const salesToday = await api.fetchSalesByLocationAndDate(storeId, new Date().toISOString().split('T')[0]);
-            //     // document.getElementById('storeSalesToday').textContent = salesToday.reduce((sum, sale) => sum + sale.quantity_sold, 0);
+            async function loadStoreDashboard(storeId) {
+                document.getElementById('dashboardContent').classList.remove('d-none');
+                const resp = await fetch(`http://localhost:8000/dashboard/store/${storeId}`);
+                const data = await resp.json();
+                document.getElementById('storeCurrentStock').textContent = data.current_stock;
+                document.getElementById('storeSalesToday').textContent = data.sales_today;
+            }
 
-            //     // Populate 'Your Products In Stock' table
-            //     // const productsInStockTable = createTable(stockHeaders, storeStock, 'storeProductsTable');
-            //     // document.getElementById('storeProductsTableContainer').innerHTML = '';
-            //     // document.getElementById('storeProductsTableContainer').appendChild(productsInStockTable);
+            async function populateStoreDropdown() {
+                try {
+                    const resp = await fetch('http://localhost:8000/locations');
+                    const locations = await resp.json();
+                    const retailStores = locations.filter(loc => loc.location_type === 'Retail Store');
+                    const selectStoreDropdown = document.getElementById('selectStore');
+                    selectStoreDropdown.innerHTML = '<option value="">Select Your Store</option>';
+                    retailStores.forEach(store => {
+                        const option = document.createElement('option');
+                        option.value = store.location_id;
+                        option.textContent = store.location_name;
+                        selectStoreDropdown.appendChild(option);
+                    });
 
-            //     // Populate 'Upcoming Deliveries' table
-            //     // const upcomingDeliveries = await api.fetchUpcomingDeliveriesForStore(storeId);
-            //     // const deliveriesTable = createTable(deliveryHeaders, upcomingDeliveries, 'upcomingDeliveriesTable');
-            //     // document.getElementById('upcomingDeliveriesTableContainer').innerHTML = '';
-            //     // document.getElementById('upcomingDeliveriesTableContainer').appendChild(deliveriesTable);
-            // }
+                    selectStoreDropdown.addEventListener('change', async (event) => {
+                        const selectedStoreId = event.target.value;
+                        if (selectedStoreId) {
+                            await loadStoreDashboard(selectedStoreId);
+                        } else {
+                            document.getElementById('dashboardContent').classList.add('d-none');
+                        }
+                    });
+                } catch (error) {
+                    console.error('Failed to load stores for dropdown:', error);
+                    document.getElementById('selectStore').innerHTML = '<option value="">Error loading stores</option>';
+                }
+            }
 
-            // async function populateStoreDropdown() {
-            //     try {
-            //         const locations = await api.fetchLocations();
-            //         const retailStores = locations.filter(loc => loc.location_type === 'Retail Store');
-            //         const selectStoreDropdown = document.getElementById('selectStore');
-            //         selectStoreDropdown.innerHTML = '<option value="">Select Your Store</option>'; // Reset dropdown
-            //         retailStores.forEach(store => {
-            //             const option = document.createElement('option');
-            //             option.value = store.location_id;
-            //             option.textContent = store.location_name;
-            //             selectStoreDropdown.appendChild(option);
-            //         });
-
-            //         selectStoreDropdown.addEventListener('change', (event) => {
-            //             const selectedStoreId = event.target.value;
-            //             if (selectedStoreId) {
-            //                 loadStoreDashboard(selectedStoreId);
-            //             } else {
-            //                 document.getElementById('dashboardContent').classList.add('d-none'); // Hide if no store selected
-            //             }
-            //         });
-            //     } catch (error) {
-            //         console.error("Failed to load stores for dropdown:", error);
-            //         document.getElementById('selectStore').innerHTML = '<option value="">Error loading stores</option>';
-            //     }
-            // }
-            // populateStoreDropdown();
+            populateStoreDropdown();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add environment-based DB configuration
- extend ORM models for partners, agents, sales, and stock
- create `services.py` with CRUD helpers and dashboard aggregations
- refactor API routes to use new service layer
- implement dashboard endpoints and locations endpoint
- enhance dashboards to fetch data from new APIs
- document new features and version 0.5.0

## Testing
- `python init_db.py`
- `uvicorn main:app --reload --port 8001` *(runs)*

------
https://chatgpt.com/codex/tasks/task_e_685d16c174bc832abf327d7c82055011