### PR TITLE
Add recent sales dashboard endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.5.0
+Version: 0.5.1
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -18,6 +18,8 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** service layer (`services.py`) with aggregation logic
 - **New:** dashboard endpoints `/dashboard/arivu` and `/dashboard/store/{id}`
 - **New:** environment variable `DATABASE_URL` controls database connection
+- **New:** `/dashboard/recent-sales` API returning latest partner sales
+- **Updated:** Arivu dashboard now displays recent sales table
 
 ## Quick Start
 1. Install dependencies: `pip install fastapi uvicorn sqlalchemy`
@@ -66,5 +68,11 @@ Fetch locations via cURL:
 curl http://localhost:8000/locations
 ```
 
+Fetch recent sales via cURL:
+
+```bash
+curl http://localhost:8000/dashboard/recent-sales
+```
+
 ## Project Status
-Version 0.5.0 adds a service layer, environment-based DB config, and dashboard APIs for aggregated data.
+Version 0.5.1 adds a recent-sales endpoint and dashboard table alongside prior service layer improvements.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -93,6 +93,16 @@
         </div>
         <small class="text-muted mt-2">Last 5 stock movements across all locations.</small>
 
+        <h3 class="mt-5 mb-3 text-secondary"><i class="bi bi-receipt-cutoff me-2"></i>Recent Sales</h3>
+        <div id="recentSalesTableContainer" class="table-responsive">
+            <div class="text-center p-5">
+                <div class="spinner-border text-secondary" role="status">
+                    <span class="visually-hidden">Loading recent sales...</span>
+                </div>
+            </div>
+        </div>
+        <small class="text-muted mt-2">Last 5 sales records from retail partners.</small>
+
     </div>
 
     <!-- Bootstrap Bundle with Popper -->
@@ -115,7 +125,32 @@
                 }
             }
 
+            async function loadRecentSales() {
+                // WHY: show recent sales data using new API (Closes: #7)
+                try {
+                    const resp = await fetch('http://localhost:8000/dashboard/recent-sales');
+                    const sales = await resp.json();
+                    const count = sales.reduce((sum, s) => sum + s.quantity_sold, 0);
+                    document.getElementById('recentSalesCount').textContent = count;
+                    const container = document.getElementById('recentSalesTableContainer');
+                    const table = document.createElement('table');
+                    table.className = 'table table-striped';
+                    table.innerHTML = `<thead><tr><th>Sale ID</th><th>Store</th><th>Product</th><th>Qty</th><th>Date</th></tr></thead><tbody></tbody>`;
+                    const tbody = table.querySelector('tbody');
+                    sales.forEach(s => {
+                        const tr = document.createElement('tr');
+                        tr.innerHTML = `<td>${s.sale_id}</td><td>${s.store_id}</td><td>${s.product_id}</td><td>${s.quantity_sold}</td><td>${s.sale_date || ''}</td>`;
+                        tbody.appendChild(tr);
+                    });
+                    container.innerHTML = '';
+                    container.appendChild(table);
+                } catch (err) {
+                    console.error('Failed to load recent sales', err);
+                }
+            }
+
             loadDashboard();
+            loadRecentSales();
         });
     </script>
 </body>

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from services import (
     get_total_retail_stock,
     get_expiring_units_count,
     get_recent_movements,
+    get_recent_sales,
     get_store_current_stock,
     get_store_sales_today,
 )
@@ -200,6 +201,23 @@ def store_dashboard(store_id: str, db: Session = Depends(get_db)):
         "current_stock": get_store_current_stock(db, store_id),
         "sales_today": get_store_sales_today(db, store_id),
     }
+
+
+@app.get("/dashboard/recent-sales")
+def recent_sales(limit: int = 5, db: Session = Depends(get_db)):
+    """Return recent retail sales for overview."""
+    # WHY: show latest sales data on dashboards (Closes: #7)
+    sales = get_recent_sales(db, limit)
+    return [
+        {
+            "sale_id": s.sale_id,
+            "store_id": s.store_id,
+            "product_id": s.product_id,
+            "quantity_sold": s.quantity_sold,
+            "sale_date": s.sale_date.isoformat() if s.sale_date else None,
+        }
+        for s in sales
+    ]
 
 
 @app.get("/locations")

--- a/services.py
+++ b/services.py
@@ -110,3 +110,16 @@ def get_store_sales_today(db: Session, store_id: str) -> int:
         .filter(and_(RetailSale.store_id == store_id, RetailSale.sale_date == today))
         .scalar()
     )
+
+
+def get_recent_sales(db: Session, limit: int = 5):
+    """Return recent retail sales records."""
+    # WHY: Provide dashboard view of latest partner sales
+    # WHAT: Query retail_sales ordered by sale_date desc
+    # HOW: adjust limit parameter to extend; remove endpoint to rollback
+    return (
+        db.query(RetailSale)
+        .order_by(RetailSale.sale_date.desc())
+        .limit(limit)
+        .all()
+    )


### PR DESCRIPTION
## Summary
- implement `get_recent_sales` service
- expose `/dashboard/recent-sales` API
- render recent sales table in Arivu dashboard
- document new endpoint and bump to v0.5.1

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d20d9be34832aa9992b7d9a4014bc