### PR TITLE
Add simple API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.5.1
+Version: 0.5.2
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -20,24 +20,25 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** environment variable `DATABASE_URL` controls database connection
 - **New:** `/dashboard/recent-sales` API returning latest partner sales
 - **Updated:** Arivu dashboard now displays recent sales table
+- **New:** Simple API key authentication using `X-API-Key` header (`API_KEY` env var)
 
 ## Quick Start
 1. Install dependencies: `pip install fastapi uvicorn sqlalchemy`
 2. Run `python init_db.py` to (re)create `arivu_foods_inventory.db` with all tables.
-3. Start API server: `uvicorn main:app --reload` (set `DATABASE_URL` as needed)
+3. Set `API_KEY` environment variable (default `changeme`) and start server: `uvicorn main:app --reload` (set `DATABASE_URL` as needed)
 4. Open `product_list.html` in browser to see product list.
 
 ## API Example
 Fetch products via cURL:
 
 ```bash
-curl http://localhost:8000/products
+curl -H 'X-API-Key: <API_KEY>' http://localhost:8000/products
 ```
 
 Fetch batches via cURL:
 
 ```bash
-curl http://localhost:8000/batches
+curl -H 'X-API-Key: <API_KEY>' http://localhost:8000/batches
 ```
 
 Create a stock movement via cURL:
@@ -45,6 +46,7 @@ Create a stock movement via cURL:
 ```bash
 curl -X POST http://localhost:8000/stock-movements \
      -H 'Content-Type: application/json' \
+     -H 'X-API-Key: <API_KEY>' \
      -d '{"movement_id":"MOVE1","product_id":"AFCMA1KG","batch_id":"B1","movement_type":"dispatch","quantity":10}'
 ```
 
@@ -53,26 +55,27 @@ Create a new product via cURL:
 ```bash
 curl -X POST http://localhost:8000/products \
      -H 'Content-Type: application/json' \
+     -H 'X-API-Key: <API_KEY>' \
      -d '{"product_id":"NEW1","product_name":"Sample","unit_of_measure":"kg","standard_pack_size":1,"mrp":100}'
 ```
 
 Fetch dashboard summary via cURL:
 
 ```bash
-curl http://localhost:8000/dashboard/arivu
+curl -H 'X-API-Key: <API_KEY>' http://localhost:8000/dashboard/arivu
 ```
 
 Fetch locations via cURL:
 
 ```bash
-curl http://localhost:8000/locations
+curl -H 'X-API-Key: <API_KEY>' http://localhost:8000/locations
 ```
 
 Fetch recent sales via cURL:
 
 ```bash
-curl http://localhost:8000/dashboard/recent-sales
+curl -H 'X-API-Key: <API_KEY>' http://localhost:8000/dashboard/recent-sales
 ```
 
 ## Project Status
-Version 0.5.1 adds a recent-sales endpoint and dashboard table alongside prior service layer improvements.
+Version 0.5.2 introduces API key authentication and updates frontend fetch calls accordingly.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -109,12 +109,15 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <!-- Custom JavaScript for this page (would be handled by main.js/components.js) -->
     <script>
+        const API_KEY = 'changeme';
         document.addEventListener('DOMContentLoaded', () => {
             console.log("Arivu Foods Dashboard loaded.");
             // WHY: load aggregate dashboard data from new API (Closes: #6)
             async function loadDashboard() {
                 try {
-                    const resp = await fetch('http://localhost:8000/dashboard/arivu');
+                    const resp = await fetch('http://localhost:8000/dashboard/arivu', {
+                        headers: {'X-API-Key': API_KEY}
+                    });
                     const data = await resp.json();
                     document.getElementById('totalProductsCount').textContent = data.total_products;
                     document.getElementById('mainWarehouseStock').textContent = data.warehouse_stock;
@@ -128,7 +131,9 @@
             async function loadRecentSales() {
                 // WHY: show recent sales data using new API (Closes: #7)
                 try {
-                    const resp = await fetch('http://localhost:8000/dashboard/recent-sales');
+                    const resp = await fetch('http://localhost:8000/dashboard/recent-sales', {
+                        headers: {'X-API-Key': API_KEY}
+                    });
                     const sales = await resp.json();
                     const count = sales.reduce((sum, s) => sum + s.quantity_sold, 0);
                     document.getElementById('recentSalesCount').textContent = count;

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,22 @@
+"""Simple API key authentication for FastAPI routes.
+
+WHY: maintain basic request authentication to ensure only authorized clients call the API.
+WHAT: validates 'X-API-Key' header against the API_KEY environment variable.
+HOW: adjust the API_KEY env var or extend with DB lookup; remove dependency to rollback.
+Closes: #8
+"""
+
+import os
+from fastapi import Header, HTTPException, status
+
+API_KEY = os.getenv("API_KEY", "changeme")
+
+
+def verify_api_key(x_api_key: str = Header(...)):
+    """Dependency to compare provided API key with expected value."""
+    if x_api_key != API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API Key",
+        )
+

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ Closes: #2.
 """
 
 from fastapi import FastAPI, Depends, HTTPException
+from auth import verify_api_key  # ensure every request carries valid API key
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
@@ -34,7 +35,11 @@ from datetime import date, timedelta
 # Create tables if not already present (initial migration)
 Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="Arivu Foods Inventory API")
+# WHY: enforce simple API key authentication across all endpoints (Closes: #8)
+app = FastAPI(
+    title="Arivu Foods Inventory API",
+    dependencies=[Depends(verify_api_key)],
+)
 
 
 class ProductCreate(BaseModel):

--- a/product_list.html
+++ b/product_list.html
@@ -112,9 +112,12 @@
         // WHAT: fetches /products endpoint and renders into table
         // HOW: call fetchProducts() on page load; remove or modify to roll back
         // Closes: #2
+        const API_KEY = 'changeme'; // simple header auth shared with backend
         document.addEventListener('DOMContentLoaded', () => {
             async function loadProducts() {
-                const response = await fetch('http://localhost:8000/products');
+                const response = await fetch('http://localhost:8000/products', {
+                    headers: {'X-API-Key': API_KEY}
+                });
                 const products = await response.json();
                 const tbody = document.getElementById('productListTableBody');
                 tbody.innerHTML = '';
@@ -130,7 +133,9 @@
 
             // WHY: display existing batches via new API (Closes: #4)
             async function loadBatches() {
-                const response = await fetch('http://localhost:8000/batches');
+                const response = await fetch('http://localhost:8000/batches', {
+                    headers: {'X-API-Key': API_KEY}
+                });
                 const batches = await response.json();
                 const tbody = document.getElementById('batchListTableBody');
                 tbody.innerHTML = '';
@@ -159,7 +164,10 @@
                 };
                 await fetch('http://localhost:8000/products', {
                     method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-API-Key': API_KEY
+                    },
                     body: JSON.stringify(product)
                 });
                 form.reset();

--- a/store_partner_dashboard.html
+++ b/store_partner_dashboard.html
@@ -83,12 +83,15 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <!-- Custom JavaScript for this page (would be handled by main.js/components.js) -->
     <script>
+        const API_KEY = 'changeme';
         document.addEventListener('DOMContentLoaded', () => {
             console.log("Store Partner Dashboard loaded.");
 
             async function loadStoreDashboard(storeId) {
                 document.getElementById('dashboardContent').classList.remove('d-none');
-                const resp = await fetch(`http://localhost:8000/dashboard/store/${storeId}`);
+                const resp = await fetch(`http://localhost:8000/dashboard/store/${storeId}`, {
+                    headers: {'X-API-Key': API_KEY}
+                });
                 const data = await resp.json();
                 document.getElementById('storeCurrentStock').textContent = data.current_stock;
                 document.getElementById('storeSalesToday').textContent = data.sales_today;
@@ -96,7 +99,9 @@
 
             async function populateStoreDropdown() {
                 try {
-                    const resp = await fetch('http://localhost:8000/locations');
+                    const resp = await fetch('http://localhost:8000/locations', {
+                        headers: {'X-API-Key': API_KEY}
+                    });
                     const locations = await resp.json();
                     const retailStores = locations.filter(loc => loc.location_type === 'Retail Store');
                     const selectStoreDropdown = document.getElementById('selectStore');


### PR DESCRIPTION
## Summary
- enforce API key authentication across the API using `auth.py`
- pass `X-API-Key` from dashboards and product list page
- document API key usage and bump version to 0.5.2

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d22ae7430832a9ecffba6bcfc4464