### PR TITLE
Serve static html pages directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.7.0
+Version: 0.7.1
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -31,6 +31,8 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** `/retail-partners` API for listing and creating partners
 - **Changed:** HTML pages load API key from `localStorage`
 - **Removed:** legacy `sqlscema.md` file
+- **New:** Static routes serve HTML pages (`register.html`, `arivu_Dashboard.html`,
+  etc.) directly from root to fix 404s after login
 
 ## Quick Start
 1. Install dependencies: `pip install -r requirements.txt`
@@ -130,5 +132,17 @@ Fetch retail partners via cURL:
 curl -u <user>:<pass> http://localhost:8000/retail-partners
 ```
 
+Fetch the registration page via cURL (no auth required):
+
+```bash
+curl http://localhost:8000/register.html
+```
+
+Fetch the Arivu dashboard HTML via cURL (after login):
+
+```bash
+curl -u <user>:<pass> http://localhost:8000/arivu_Dashboard.html
+```
+
 ## Project Status
-Version 0.7.0 introduces HTTP Basic authentication with a login page served from the backend. Run `python init_db.py` to create or update tables before starting the server.
+Version 0.7.1 fixes missing static page routes so registration and dashboards load correctly. Run `python init_db.py` if you haven't created the database yet, then `uvicorn main:app --reload` to start the server.

--- a/main.py
+++ b/main.py
@@ -56,6 +56,25 @@ app.mount("/ui", StaticFiles(directory="."), name="ui")
 def serve_login():
     """Return login page so users can authenticate via browser."""
     return FileResponse("login.html")
+# Additional static file routes so relative links work from login page
+# WHY: fix 404 errors for pages like register.html when accessed directly
+# WHAT: expose key HTML pages at the root path
+# HOW: remove these routes if StaticFiles mount is changed
+@app.get("/register.html", response_class=HTMLResponse)
+def serve_register_page():
+    return FileResponse("register.html")
+
+@app.get("/arivu_Dashboard.html", response_class=HTMLResponse)
+def serve_arivu_dashboard_page():
+    return FileResponse("arivu_Dashboard.html")
+
+@app.get("/store_partner_dashboard.html", response_class=HTMLResponse)
+def serve_store_dashboard_page():
+    return FileResponse("store_partner_dashboard.html")
+
+@app.get("/product_list.html", response_class=HTMLResponse)
+def serve_product_list_page():
+    return FileResponse("product_list.html")
 # Individual routes use HTTP Basic auth dependency so endpoints require login
 auth_dep = Depends(verify_basic_auth)
 


### PR DESCRIPTION
## Summary
- add explicit routes in `main.py` to serve HTML pages from root
- document new static routes and bump version to 0.7.1

## Testing
- `uvicorn main:app --reload`
- `curl http://127.0.0.1:8000/register.html`
- `curl http://127.0.0.1:8000/arivu_Dashboard.html`


------
https://chatgpt.com/codex/tasks/task_e_685d36ab96ec832abd3eab541131ac12