### PR TITLE
Add store partner account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.7.1
+Version: 0.7.2
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -29,6 +29,7 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** `/retail-sales` endpoint records store sales and adjusts stock
 - **New:** detailed store dashboard endpoints `/dashboard/store/{id}/stock` and `/dashboard/store/{id}/deliveries`
 - **New:** `/retail-partners` API for listing and creating partners
+- **New:** `/store-partner-accounts` API creates partner record and login user
 - **Changed:** HTML pages load API key from `localStorage`
 - **Removed:** legacy `sqlscema.md` file
 - **New:** Static routes serve HTML pages (`register.html`, `arivu_Dashboard.html`,
@@ -132,6 +133,15 @@ Fetch retail partners via cURL:
 curl -u <user>:<pass> http://localhost:8000/retail-partners
 ```
 
+Create a store partner account via cURL:
+
+```bash
+curl -X POST http://localhost:8000/store-partner-accounts \
+     -H 'Content-Type: application/json' \
+     -u <user>:<pass> \
+     -d '{"store_id":"NEWSTORE","location_id":"LOC1","store_name":"Test Store","username":"storeuser","password":"secret"}'
+```
+
 Fetch the registration page via cURL (no auth required):
 
 ```bash
@@ -145,4 +155,4 @@ curl -u <user>:<pass> http://localhost:8000/arivu_Dashboard.html
 ```
 
 ## Project Status
-Version 0.7.1 fixes missing static page routes so registration and dashboards load correctly. Run `python init_db.py` if you haven't created the database yet, then `uvicorn main:app --reload` to start the server.
+Version 0.7.2 adds combined store partner account creation. Run `python init_db.py` if you haven't created the database yet, then `uvicorn main:app --reload` to start the server.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -108,8 +108,12 @@
         <form id="partnerForm" class="row g-2">
             <div class="col-md-2"><input type="text" class="form-control" id="storeId" placeholder="Store ID" required></div>
             <div class="col-md-2"><input type="text" class="form-control" id="locationId" placeholder="Location ID" required></div>
-            <div class="col-md-3"><input type="text" class="form-control" id="storeName" placeholder="Store Name" required></div>
-            <div class="col-md-3"><input type="text" class="form-control" id="contactPerson" placeholder="Contact"></div>
+            <div class="col-md-2"><input type="text" class="form-control" id="storeName" placeholder="Store Name" required></div>
+            <div class="col-md-2"><input type="text" class="form-control" id="contactPerson" placeholder="Contact"></div>
+            <div class="col-md-2"><input type="text" class="form-control" id="contactNumber" placeholder="Phone"></div>
+            <div class="col-md-2"><input type="email" class="form-control" id="email" placeholder="Email"></div>
+            <div class="col-md-2"><input type="text" class="form-control" id="username" placeholder="Login User" required></div>
+            <div class="col-md-2"><input type="password" class="form-control" id="password" placeholder="Password" required></div>
             <div class="col-md-2"><button class="btn btn-primary w-100" type="submit">Add</button></div>
         </form>
 
@@ -192,16 +196,20 @@
             const partnerForm = document.getElementById('partnerForm');
             partnerForm.addEventListener('submit', async (e) => {
                 e.preventDefault();
-                const partner = {
+                const payload = {
                     store_id: document.getElementById('storeId').value,
                     location_id: document.getElementById('locationId').value,
                     store_name: document.getElementById('storeName').value,
-                    contact_person: document.getElementById('contactPerson').value || null
+                    contact_person: document.getElementById('contactPerson').value || null,
+                    contact_number: document.getElementById('contactNumber').value || null,
+                    email: document.getElementById('email').value || null,
+                    username: document.getElementById('username').value,
+                    password: document.getElementById('password').value
                 };
-                await fetch('/retail-partners', {
+                await fetch('/store-partner-accounts', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json', ...authHeaders()},
-                    body: JSON.stringify(partner)
+                    body: JSON.stringify(payload)
                 });
                 partnerForm.reset();
                 loadRetailPartners();


### PR DESCRIPTION
## Summary
- support new partner+login creation with `/store-partner-accounts`
- expose helper to create partner and user together
- extend Arivu dashboard form with account fields
- document usage and bump version

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d39776c98832aa4ec07ce26aac24c