### PR TITLE
Add /login.html route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.7.3
+Version: 0.7.4
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -35,6 +35,7 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** Static routes serve HTML pages (`register.html`, `arivu_Dashboard.html`,
   etc.) directly from root to fix 404s after login
 - **New:** `/warehouse-stock` endpoint lists main warehouse inventory and dashboard form allows adding batches
+- **New:** `/login.html` route serves the login page alongside root
 
 ## Quick Start
 1. Install dependencies: `pip install -r requirements.txt`
@@ -164,6 +165,12 @@ Fetch the registration page via cURL (no auth required):
 curl http://localhost:8000/register.html
 ```
 
+Fetch the login page via cURL (no auth required):
+
+```bash
+curl http://localhost:8000/login.html
+```
+
 Fetch the Arivu dashboard HTML via cURL (after login):
 
 ```bash
@@ -171,4 +178,4 @@ curl -u <user>:<pass> http://localhost:8000/arivu_Dashboard.html
 ```
 
 ## Project Status
-Version 0.7.3 introduces warehouse inventory management with a new `/warehouse-stock` API and batch creation form on the dashboard. Run `python init_db.py` if you haven't created the database yet, then `uvicorn main:app --reload` to start the server.
+Version 0.7.4 adds an alias route `/login.html` for the login page. Previous features including the `/warehouse-stock` API remain unchanged. Run `python init_db.py` if you haven't created the database yet, then `uvicorn main:app --reload` to start the server.

--- a/main.py
+++ b/main.py
@@ -58,6 +58,13 @@ app.mount("/ui", StaticFiles(directory="."), name="ui")
 def serve_login():
     """Return login page so users can authenticate via browser."""
     return FileResponse("login.html")
+
+# WHY: allow direct access via /login.html as well as root (Closes: #20)
+# WHAT: serve same login page when requested by filename
+# HOW: remove this route if frontend uses a dedicated framework router
+@app.get("/login.html", response_class=HTMLResponse)
+def serve_login_page_alias():
+    return FileResponse("login.html")
 # Additional static file routes so relative links work from login page
 # WHY: fix 404 errors for pages like register.html when accessed directly
 # WHAT: expose key HTML pages at the root path


### PR DESCRIPTION
## Summary
- expose `GET /login.html` to serve login page directly
- document new route and bump project version to 0.7.4

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d42473254832aa52ffa4ca7d17ac9