### PR TITLE
Support multi-product batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arivu Foods Inventory System
 
-Version: 0.7.7
+Version: 0.7.8
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
 
@@ -40,6 +40,7 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** Dispatch form on Arivu dashboard posts to `/stock-movements`
 - **New:** `init_db.py` now loads sample products from `products.csv`
 - **New:** `products.html` embedded in `arivu_Dashboard.html` showing product table
+- **Changed:** Batches now support multiple products via new `batch_products` table and auto-calculate expiry 90 days from manufacturing
 
 ## Quick Start
 1. Install dependencies: `pip install -r requirements.txt`
@@ -154,7 +155,7 @@ Create a batch via cURL:
 curl -X POST http://localhost:8000/batches \
      -H 'Content-Type: application/json' \
      -u <user>:<pass> \
-     -d '{"batch_id":"B1","product_id":"AFCMA1KG","date_manufactured":"2024-01-01","quantity_produced":100}'
+     -d '{"batch_id":"B1","date_manufactured":"2024-01-01","items":[{"product_id":"AFCMA1KG","quantity_produced":50},{"product_id":"AFDMIX","quantity_produced":50}]}'
 ```
 
 Fetch warehouse stock via cURL:
@@ -197,4 +198,4 @@ curl http://localhost:8000/products.html
 ```
 
 ## Project Status
-Version 0.7.7 loads sample products from `products.csv` during database initialization and embeds a product list inside the Arivu dashboard. Existing dispatch and batch features remain. Run `python init_db.py` to recreate the database with sample data, then `uvicorn main:app --reload` to start the server.
+Version 0.7.8 introduces `batch_products` for recording multiple products per batch. Expiry dates are now auto-set 90 days from manufacturing if omitted. Run `python init_db.py` after pulling to recreate the database, then `uvicorn main:app --reload`.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -134,14 +134,19 @@
                     <div class="modal-body">
                         <form id="batchForm" class="row g-2">
                             <div class="col-12"><input type="text" class="form-control" id="batchIdInput" placeholder="Batch ID" required></div>
-                            <div class="col-12">
-                                <select class="form-select" id="batchProduct" required>
-                                    <option value="">Select Product</option>
-                                </select>
+                            <div class="col-12" id="batchItems">
+                                <div class="row g-2 batch-item mb-2">
+                                    <div class="col-8">
+                                        <select class="form-select product-field" required>
+                                            <option value="">Select Product</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-4"><input type="number" class="form-control qty-field" placeholder="Qty" required></div>
+                                </div>
                             </div>
+                            <div class="col-12"><button type="button" class="btn btn-outline-secondary btn-sm" id="addItemBtn">Add Product</button></div>
                             <div class="col-6"><input type="date" class="form-control" id="manufacturedDate" required></div>
-                            <div class="col-6"><input type="number" class="form-control" id="batchQty" placeholder="Qty" required></div>
-                            <div class="col-12"><input type="date" class="form-control" id="expiryDate"></div>
+                            <div class="col-6"><input type="date" class="form-control" id="expiryDate" readonly></div>
                             <div class="col-12"><button class="btn btn-primary w-100" type="submit" data-bs-dismiss="modal">Save Batch</button></div>
                         </form>
                     </div>
@@ -301,16 +306,18 @@
                 }
             }
 
+            let productOptions = [];
             async function populateProductDropdown() {
                 const resp = await fetch('/products', { headers: authHeaders() });
-                const products = await resp.json();
-                const select = document.getElementById('batchProduct');
-                select.innerHTML = '<option value="">Select Product</option>';
-                products.forEach(p => {
-                    const opt = document.createElement('option');
-                    opt.value = p.product_id;
-                    opt.textContent = p.product_name;
-                    select.appendChild(opt);
+                productOptions = await resp.json();
+                document.querySelectorAll('.product-field').forEach(sel => {
+                    sel.innerHTML = '<option value="">Select Product</option>';
+                    productOptions.forEach(p => {
+                        const opt = document.createElement('option');
+                        opt.value = p.product_id;
+                        opt.textContent = p.product_name;
+                        sel.appendChild(opt);
+                    });
                 });
             }
 
@@ -327,11 +334,13 @@
                 batchSelect.innerHTML = '<option value="">Select Batch</option>';
                 storeSelect.innerHTML = '<option value="">Select Store</option>';
                 batches.forEach(b => {
-                    const opt = document.createElement('option');
-                    opt.value = b.batch_id;
-                    opt.textContent = `${b.batch_id} (${b.product_id})`;
-                    opt.dataset.product = b.product_id;
-                    batchSelect.appendChild(opt);
+                    b.items.forEach(it => {
+                        const opt = document.createElement('option');
+                        opt.value = b.batch_id;
+                        opt.textContent = `${b.batch_id} (${it.product_id})`;
+                        opt.dataset.product = it.product_id;
+                        batchSelect.appendChild(opt);
+                    });
                 });
                 partners.forEach(p => {
                     const opt = document.createElement('option');
@@ -343,14 +352,39 @@
 
             // Dashboard.md lines 21-22: handle quick batch creation modal
             const batchForm = document.getElementById('batchForm');
+            const batchItems = document.getElementById('batchItems');
+            const addItemBtn = document.getElementById('addItemBtn');
+
+            addItemBtn.addEventListener('click', () => {
+                const div = document.createElement('div');
+                div.className = 'row g-2 batch-item mb-2';
+                div.innerHTML = `<div class="col-8"><select class="form-select product-field" required></select></div><div class="col-4"><input type="number" class="form-control qty-field" placeholder="Qty" required></div>`;
+                batchItems.appendChild(div);
+                populateProductDropdown();
+            });
+
+            document.getElementById('manufacturedDate').addEventListener('change', e => {
+                const val = e.target.value;
+                if (val) {
+                    const d = new Date(val);
+                    d.setDate(d.getDate() + 90);
+                    document.getElementById('expiryDate').value = d.toISOString().split('T')[0];
+                }
+            });
             batchForm.addEventListener('submit', async (e) => {
                 e.preventDefault();
+                const items = [];
+                document.querySelectorAll('#batchItems .batch-item').forEach(row => {
+                    items.push({
+                        product_id: row.querySelector('.product-field').value,
+                        quantity_produced: parseInt(row.querySelector('.qty-field').value)
+                    });
+                });
                 const batch = {
                     batch_id: document.getElementById('batchIdInput').value,
-                    product_id: document.getElementById('batchProduct').value,
                     date_manufactured: document.getElementById('manufacturedDate').value,
-                    quantity_produced: parseInt(document.getElementById('batchQty').value),
-                    expiry_date: document.getElementById('expiryDate').value || null
+                    expiry_date: document.getElementById('expiryDate').value || null,
+                    items
                 };
                 await fetch('/batches', {
                     method: 'POST',
@@ -358,6 +392,8 @@
                     body: JSON.stringify(batch)
                 });
                 batchForm.reset();
+                batchItems.innerHTML = '<div class="row g-2 batch-item mb-2"><div class="col-8"><select class="form-select product-field" required></select></div><div class="col-4"><input type="number" class="form-control qty-field" placeholder="Qty" required></div></div>';
+                populateProductDropdown();
                 loadWarehouseStock();
                 loadDashboard();
             });

--- a/main.py
+++ b/main.py
@@ -102,15 +102,20 @@ class ProductCreate(BaseModel):
     mrp: float | None = None
 
 
+class BatchItem(BaseModel):
+    """Single product entry within a batch."""
+    product_id: str
+    quantity_produced: int
+
+
 class BatchCreate(BaseModel):
     """Schema for creating batches."""
     # WHY: validate incoming batch data for POST /batches
     batch_id: str
-    product_id: str
     date_manufactured: date
-    quantity_produced: int
     expiry_date: date | None = None
     remarks: str | None = None
+    items: list[BatchItem]
 
 
 class StockMovementCreate(BaseModel):
@@ -230,17 +235,24 @@ def list_batches(db: Session = Depends(get_db)):
     """Return all batches."""
     # WHY: list production batches for inventory tracking (Closes: #4)
     batches = get_all_batches(db)
-    return [
-        {
-            "batch_id": b.batch_id,
-            "product_id": b.product_id,
-            "date_manufactured": b.date_manufactured.isoformat(),
-            "quantity_produced": b.quantity_produced,
-            "expiry_date": b.expiry_date.isoformat() if b.expiry_date else None,
-            "remarks": b.remarks,
-        }
-        for b in batches
-    ]
+    results = []
+    for b, items in batches:
+        results.append(
+            {
+                "batch_id": b.batch_id,
+                "date_manufactured": b.date_manufactured.isoformat(),
+                "expiry_date": b.expiry_date.isoformat() if b.expiry_date else None,
+                "remarks": b.remarks,
+                "items": [
+                    {
+                        "product_id": i.product_id,
+                        "quantity_produced": i.quantity_produced,
+                    }
+                    for i in items
+                ],
+            }
+        )
+    return results
 
 
 @app.post("/batches", status_code=201, dependencies=[auth_dep])
@@ -249,7 +261,11 @@ def create_batch(batch: BatchCreate, db: Session = Depends(get_db)):
     existing = db.get(Batch, batch.batch_id)
     if existing:
         raise HTTPException(status_code=400, detail="Batch ID already exists")
-    db_batch = svc_create_batch(db, batch.dict())
+    batch_data = batch.dict()
+    items = batch_data.pop("items")
+    if not batch_data.get("expiry_date"):
+        batch_data["expiry_date"] = batch_data["date_manufactured"] + timedelta(days=90)
+    db_batch = svc_create_batch(db, batch_data, [i for i in items])
     # WHY: update warehouse inventory when a batch is produced
     add_new_batch_to_inventory(db, db_batch)
     return {"message": "Batch created", "batch_id": db_batch.batch_id}

--- a/models.py
+++ b/models.py
@@ -35,17 +35,27 @@ class Location(Base):
 
 
 class Batch(Base):
-    """Batches of manufactured products."""
-    # WHY: represent production lots for expiry tracking
-    # WHAT: maps to batches table
-    # HOW: extend with relationships if needed; delete class to rollback
+    """Batch metadata shared by contained products."""
+    # WHY: allow multiple products under one batch identifier
+    # WHAT: holds manufactured date and expiry, while items recorded separately
+    # HOW: extend with relationship to BatchProduct; remove items to rollback
     __tablename__ = 'batches'
     batch_id = Column(String(50), primary_key=True)
-    product_id = Column(String(50), ForeignKey('products.product_id'), nullable=False)
     date_manufactured = Column(Date, nullable=False)
-    quantity_produced = Column(Integer, nullable=False)
     expiry_date = Column(Date)
     remarks = Column(String)
+
+
+class BatchProduct(Base):
+    """Association of products and quantities for each batch."""
+    # WHY: support multiple products per batch (Closes inventory request)
+    # WHAT: new table mapping batch_id to product_id and qty
+    # HOW: delete class and related tables to roll back
+    __tablename__ = 'batch_products'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    batch_id = Column(String(50), ForeignKey('batches.batch_id'), nullable=False)
+    product_id = Column(String(50), ForeignKey('products.product_id'), nullable=False)
+    quantity_produced = Column(Integer, nullable=False)
 
 
 class StockMovement(Base):

--- a/product_list.html
+++ b/product_list.html
@@ -146,12 +146,14 @@
                 const tbody = document.getElementById('batchListTableBody');
                 tbody.innerHTML = '';
                 batches.forEach(b => {
-                    const row = tbody.insertRow();
-                    row.insertCell().textContent = b.batch_id;
-                    row.insertCell().textContent = b.product_id;
-                    row.insertCell().textContent = b.date_manufactured;
-                    row.insertCell().textContent = b.quantity_produced;
-                    row.insertCell().textContent = b.expiry_date || '';
+                    b.items.forEach(it => {
+                        const row = tbody.insertRow();
+                        row.insertCell().textContent = b.batch_id;
+                        row.insertCell().textContent = it.product_id;
+                        row.insertCell().textContent = b.date_manufactured;
+                        row.insertCell().textContent = it.quantity_produced;
+                        row.insertCell().textContent = b.expiry_date || '';
+                    });
                 });
             }
 

--- a/schema.sql
+++ b/schema.sql
@@ -39,12 +39,19 @@ CREATE TABLE agents (
 
 CREATE TABLE batches (
     batch_id VARCHAR(50) PRIMARY KEY,
-    product_id VARCHAR(50) NOT NULL,
     date_manufactured DATE NOT NULL,
-    quantity_produced INT NOT NULL,
     expiry_date DATE,
-    remarks TEXT,
-    CONSTRAINT fk_batch_product FOREIGN KEY (product_id) REFERENCES products(product_id)
+    remarks TEXT
+);
+
+-- New mapping table allowing multiple products per batch
+CREATE TABLE batch_products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    batch_id VARCHAR(50) NOT NULL,
+    product_id VARCHAR(50) NOT NULL,
+    quantity_produced INT NOT NULL,
+    CONSTRAINT fk_bp_batch FOREIGN KEY (batch_id) REFERENCES batches(batch_id),
+    CONSTRAINT fk_bp_product FOREIGN KEY (product_id) REFERENCES products(product_id)
 );
 
 CREATE TABLE current_stock (

--- a/services.py
+++ b/services.py
@@ -14,6 +14,7 @@ from datetime import date, timedelta
 from models import (
     Product,
     Batch,
+    BatchProduct,
     StockMovement,
     CurrentStock,
     RetailSale,
@@ -37,12 +38,31 @@ def create_product(db: Session, data: dict) -> Product:
 
 
 def get_all_batches(db: Session):
-    return db.query(Batch).all()
+    """Return batches with their associated product items."""
+    # WHY: support multi-product batches after schema change
+    batches = db.query(Batch).all()
+    result = []
+    for b in batches:
+        items = (
+            db.query(BatchProduct)
+            .filter(BatchProduct.batch_id == b.batch_id)
+            .all()
+        )
+        result.append((b, items))
+    return result
 
 
-def create_batch(db: Session, data: dict) -> Batch:
+def create_batch(db: Session, data: dict, items: list[dict]) -> Batch:
+    """Insert a batch and its product items."""
     batch = Batch(**data)
     db.add(batch)
+    for itm in items:
+        bp = BatchProduct(
+            batch_id=batch.batch_id,
+            product_id=itm["product_id"],
+            quantity_produced=itm["quantity_produced"],
+        )
+        db.add(bp)
     db.commit()
     db.refresh(batch)
     return batch
@@ -163,31 +183,33 @@ def create_user(db: Session, data: dict) -> User:
 
 # --- Inventory adjustments ---
 def add_new_batch_to_inventory(db: Session, batch: Batch, warehouse_id: str = "MAIN_WH") -> None:
-    """Insert new batch quantity into CurrentStock at the main warehouse.
-
-    WHY: keep CurrentStock table in sync with production batches. Closes inventory tracking ticket.
-    WHAT: create or update CurrentStock record when a new batch is produced.
-    HOW: adjust warehouse_id or remove call from POST /batches to roll back."""
-    stock = (
-        db.query(CurrentStock)
-        .filter(
-            CurrentStock.product_id == batch.product_id,
-            CurrentStock.batch_id == batch.batch_id,
-            CurrentStock.location_id == warehouse_id,
-        )
-        .first()
+    """Insert batch item quantities into CurrentStock at the main warehouse."""
+    items = (
+        db.query(BatchProduct)
+        .filter(BatchProduct.batch_id == batch.batch_id)
+        .all()
     )
-    if stock:
-        stock.quantity += batch.quantity_produced
-    else:
-        stock = CurrentStock(
-            stock_id=f"{batch.batch_id}-{warehouse_id}",
-            product_id=batch.product_id,
-            batch_id=batch.batch_id,
-            location_id=warehouse_id,
-            quantity=batch.quantity_produced,
+    for item in items:
+        stock = (
+            db.query(CurrentStock)
+            .filter(
+                CurrentStock.product_id == item.product_id,
+                CurrentStock.batch_id == batch.batch_id,
+                CurrentStock.location_id == warehouse_id,
+            )
+            .first()
         )
-        db.add(stock)
+        if stock:
+            stock.quantity += item.quantity_produced
+        else:
+            stock = CurrentStock(
+                stock_id=f"{batch.batch_id}-{warehouse_id}-{item.product_id}",
+                product_id=item.product_id,
+                batch_id=batch.batch_id,
+                location_id=warehouse_id,
+                quantity=item.quantity_produced,
+            )
+            db.add(stock)
     db.commit()
 
 


### PR DESCRIPTION
## Summary
- add `batch_products` table for many-to-one batch items
- adjust ORM models for new table
- allow batch creation with multiple products
- auto-calculate expiry 90 days from manufacturing
- update dashboard modal and listings
- document multi-product batches and version bump

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d68355af4832aafe27743de2c637f