### PR TITLE
Fix dashboard sync for batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arivu Foods Inventory System
 
 
-Version: 0.9.0
+Version: 0.9.1
 
 
 This repository contains initial scripts to set up the inventory database and a basic FastAPI backend.
@@ -45,6 +45,7 @@ This repository contains initial scripts to set up the inventory database and a 
 - **New:** `products.html` embedded in `arivu_Dashboard.html` showing product table
 - **Changed:** Batches now support multiple products via new `batch_products` table and auto-calculate expiry 90 days from manufacturing
 - **New:** `/warehouse-stock/summary` endpoint shows total quantity per product in the main warehouse
+- **Updated:** Dispatch dropdown now refreshes after creating or sending a batch to keep forms in sync
 =======
 
 ## Quick Start
@@ -217,4 +218,4 @@ curl http://localhost:8000/products.html
 ```
 
 ## Project Status
-Version 0.9.0 adds a CSV sync utility. Run `python main.py init-db` to recreate the database, `python main.py sync-products` whenever `products.csv` changes, then start the server with `uvicorn main:app --reload`.
+Version 0.9.1 improves dashboard sync. Run `python main.py init-db` to recreate the database, `python main.py sync-products` whenever `products.csv` changes, then start the server with `uvicorn main:app --reload`.

--- a/arivu_Dashboard.html
+++ b/arivu_Dashboard.html
@@ -423,6 +423,10 @@
                 batchForm.reset();
                 batchItems.innerHTML = '<div class="row g-2 batch-item mb-2"><div class="col-8"><select class="form-select product-field" required></select></div><div class="col-4"><input type="number" class="form-control qty-field" placeholder="Qty" required></div></div>';
                 populateProductDropdown();
+                // WHY: update dispatch dropdown after new batch so it can be dispatched without page refresh
+                // WHAT: ensures batch creation and dispatch form stay in sync (Closes: internal issue #sync)
+                // HOW: call populateDispatchForm() whenever a batch is created
+                populateDispatchForm();
                 loadWarehouseStock();
                 loadWarehouseTotals();
                 loadDashboard();
@@ -474,6 +478,10 @@
                 await loadWarehouseTotals();
                 await loadDashboard();
                 await loadRecentMovements();
+                // WHY: refresh dropdowns so next dispatch uses updated batch list
+                // WHAT: keeps dispatch form synced after each movement
+                // HOW: call populateDispatchForm here; remove to revert
+                populateDispatchForm();
             });
 
             loadDashboard();

--- a/main.py
+++ b/main.py
@@ -911,6 +911,8 @@ def create_movement(movement: StockMovementCreate, db: Session = Depends(get_db)
         raise HTTPException(status_code=400, detail="Movement ID already exists")
     db_move = create_movement(db, {**movement.dict(), "movement_date": date.today()})
     # WHY: adjust CurrentStock on dispatch or receipt
+    # WHAT: front-end dashboard relies on this to update stock tables
+    # HOW: remove this call if inventory syncing is handled elsewhere
     dispatch_stock(db, db_move)
     return {"message": "Movement recorded", "movement_id": db_move.movement_id}
 


### PR DESCRIPTION
## Summary
- refresh dispatch dropdown after creating or sending a batch
- comment stock movement function for clarity
- document dashboard sync fix and bump version to 0.9.1

## Testing
- `uvicorn main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685d86ecd3e0832a8492639f4309939a